### PR TITLE
filetool.sh: Prevent gratuitous change to .filetool.lst's timestamp

### DIFF
--- a/usr/bin/filetool.sh
+++ b/usr/bin/filetool.sh
@@ -161,7 +161,10 @@ echo "${D2#/dev/}"/$FULLPATH > /etc/sysconfig/backup_device
 trap failed SIGTERM
 
 if [ "$BACKUP" ] ; then
+  # Use a dummy file to save .filetool.lst's timestamp, so we can restore it after sed changes it
+  dummy=$(mktemp); touch -r /opt/.filetool.lst $dummy
   sed -i /^$/d /opt/.filetool.lst
+  touch -r $dummy /opt/.filetool.lst; rm $dummy
   if [ "$SAFE" ]; then
     if [ -r $MOUNTPOINT/"$FULLPATH"/${MYDATA}.tgz.bfe -o -r $MOUNTPOINT/"$FULLPATH"/${MYDATA}.tgz ]; then                     
       echo -n "Copying existing backup to $MOUNTPOINT/"$FULLPATH"/${MYDATA}bk.[tgz|tgz.bfe] .. "  


### PR DESCRIPTION
Backup operation ("filetool.sh -b") causes needless change to .filetool.lst's timestamp. For users who backup their system using a timestamp-sensitive tool such as rsync, seeing .filetool.lst in the list of changed files causes confusion/alarm.